### PR TITLE
Add typing to mapOf

### DIFF
--- a/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
+++ b/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
@@ -15,7 +15,7 @@ class ExpoLaunchArgumentsModule : Module() {
 
     // Sets constant properties on the module. Can take a dictionary or a closure that returns a dictionary.
     Constants(
-      "launchArguments" to mapOf()
+      "launchArguments" to mapOf<String, String>()
     )
 
   }


### PR DESCRIPTION
I'm new to Android development, but when trying to building locally I get a failure with this error:

```
> Task :expo-launch-arguments:compileDebugKotlin FAILED
e: /Users/rbimr049/projects/rGuest/node_modules/expo-launch-arguments/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt: (18, 28): Not enough information to infer type variable K
```
Making this change locally causes the problem to disappear. Since we are talking about launch arguments, I figured string keys and string values would be appropriate.

On the other hand, clearly folks are still able to build the Android app, so maybe the issue I am seeing has to do with my local setup. Still, this may be worth keeping in mind if other folks report this issue.