### PR TITLE
Add launchArguments for Android

### DIFF
--- a/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
+++ b/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
@@ -2,116 +2,97 @@ package expo.modules.launcharguments
 
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import expo.modules.core.interfaces.Package
-import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.core.interfaces.ActivityProvider
-import expo.modules.core.Promise
-import expo.modules.core.ExportedModule
+import android.content.Context
+
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.exception.CodedException
+
+import android.content.Intent
 import android.os.Bundle
 import android.app.Activity
-import android.content.Context
-import android.content.Intent
+import expo.modules.core.errors.CurrentActivityNotFoundException
 import java.util.HashMap
 
 const val MODULE_NAME = "ExpoLaunchArguments"
 
-class ExpoLaunchArgumentsPackage : Package {
-    override fun createReactActivityLifecycleListeners(activityContext: Context): List<ReactActivityLifecycleListener> {
-        return listOf(ExpoLaunchArgumentsActivityLifecycleListener())
-    }
-}
-
-class ExpoLaunchArgumentsActivityLifecycleListener : ReactActivityLifecycleListener {
-    override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
-        val module = ExpoLaunchArgumentsModule.getModule()
-        module.setParsedIntentExtrasFromIntent(activity.intent)
-    }
-}
-
 class ExpoLaunchArgumentsModule : Module() {
-    private val DETOX_LAUNCH_ARGS_KEY = "launchArgs"
-    private val ACTIVITY_WAIT_INTERVAL = 100L
-    private val ACTIVITY_WAIT_TRIES = 200
-    private var parsedIntentExtras: HashMap<String, Any>? = null
 
-     override fun definition() = ModuleDefinition {
-      Name(MODULE_NAME)
-      Constants {
+    override fun definition() = ModuleDefinition {
+        Name(MODULE_NAME)
+        Constants {
           waitForActivity()
-          val arguments: HashMap<String, Any>
-          arguments = HashMap(parsedIntentExtras ?: HashMap())
           return@Constants mapOf(
-              "launchArguments" to arguments
+            "launchArguments" to parseIntentExtras()
           )
-      }
-    }
-
-    companion object {
-        private lateinit var instance: ExpoLaunchArgumentsModule
-
-        fun getModule(): ExpoLaunchArgumentsModule {
-            return instance
         }
     }
 
-
-    fun setParsedIntentExtrasFromIntent(intent: Intent) {
-      parsedIntentExtras = parseIntentExtrasFromIntent(intent)
-    }
-
-    private fun parseIntentExtrasFromIntent(intent: Intent): HashMap<String, Any> {
-      val map = HashMap<String, Any>()
-
-      if (intent == null) {
-          return map
-      }
-      map.put("intent", intent.toString())
-      parseDetoxExtras(map, intent)
-      parseADBArgsExtras(map, intent)
-      return map
-    }
-
-    private fun parseDetoxExtras(map: HashMap<String, Any>, intent: Intent) {
-      val extrasBundle = intent.getBundleExtra(DETOX_LAUNCH_ARGS_KEY)
-      if (extrasBundle != null) {
-          map.put("extrasBundle", extrasBundle.toString())
-          for (key in extrasBundle.keySet()) {
-              map[key] = extrasBundle.getString(key) ?: ""
-          }
-      }
-    }
-
-    private fun parseADBArgsExtras(map: HashMap<String, Any>, intent: Intent) {
-      val bundleExtras = intent.extras
-      if (bundleExtras != null) {
-          map.put("bundleExtras", bundleExtras.toString())
-          for (key in bundleExtras.keySet()) {
-              if (key != DETOX_LAUNCH_ARGS_KEY && key != "android.nfc.extra.NDEF_MESSAGES") {
-                  val value = bundleExtras.get(key)
-                  if (value is Int || value is Double || value is Boolean || value is String) {
-                      map[key] = value
-                  } else if (value != null) {
-                      map[key] = value.toString()
-                  }
-              }
-          }
-      }
-    }
+    private val DETOX_LAUNCH_ARGS_KEY = "launchArgs"
+    private val ACTIVITY_WAIT_INTERVAL = 100L
+    private val ACTIVITY_WAIT_TRIES = 200
 
 
     private fun waitForActivity() {
-      var tries = 0
-      while (tries < ACTIVITY_WAIT_TRIES && parsedIntentExtras === null) {
-          sleep(ACTIVITY_WAIT_INTERVAL)
-          tries++
-      }
+        var tries = 0
+        while (tries < ACTIVITY_WAIT_TRIES && getCurrentActivity() == null) {
+            sleep(ACTIVITY_WAIT_INTERVAL)
+            tries++
+        }
+    }
+
+    private fun parseIntentExtras(): HashMap<String, Any> {
+        val map = HashMap<String, Any>()
+
+        var activity = getCurrentActivity()
+        if(activity == null) {
+          return map
+        }
+
+        val intent = activity.intent
+        if (intent == null) {
+          return map
+        }
+
+        parseDetoxExtras(map, intent)
+        parseADBArgsExtras(map, intent)
+        return map
+    }
+
+    private fun getCurrentActivity (): Activity? {
+        return appContext.activityProvider?.currentActivity
+    }
+
+    private fun parseDetoxExtras(map: HashMap<String, Any>, intent: Intent) {
+        val bundle = intent.getBundleExtra(DETOX_LAUNCH_ARGS_KEY)
+        if (bundle != null) {
+            for (key in bundle.keySet()) {
+                map[key] = bundle.getString(key) ?: ""
+            }
+        }
+    }
+
+    private fun parseADBArgsExtras(map: HashMap<String, Any>, intent: Intent) {
+        val bundleExtras = intent.extras
+        if (bundleExtras != null) {
+            for (key in bundleExtras.keySet()) {
+                if (key != DETOX_LAUNCH_ARGS_KEY && key != "android.nfc.extra.NDEF_MESSAGES") {
+                    val value = bundleExtras.get(key)
+                    if (value is Int || value is Double || value is Boolean || value is String) {
+                        map[key] = value
+                    } else if (value != null) {
+                        map[key] = value.toString()
+                    }
+                }
+            }
+        }
     }
 
     private fun sleep(ms: Long) {
-      try {
-          Thread.sleep(ms)
-      } catch (e: InterruptedException) {
-          e.printStackTrace()
-      }
-  }
+        try {
+            Thread.sleep(ms)
+        } catch (e: InterruptedException) {
+            e.printStackTrace()
+        }
+    }
 }

--- a/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
+++ b/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
@@ -16,10 +16,6 @@ const val MODULE_NAME = "ExpoLaunchArguments"
 
 class ExpoLaunchArgumentsModule : Module() {
 
-  init {
-        waitForActivity()
-    }
-
     override fun definition() = ModuleDefinition {
         Name(MODULE_NAME)
 
@@ -46,6 +42,8 @@ class ExpoLaunchArgumentsModule : Module() {
     private fun parseIntentExtras(): HashMap<String, Any> {
         val map = HashMap<String, Any>()
 
+        waitForActivity()
+
         var activity = getCurrentActivity()
         if(activity == null) {
           return map
@@ -62,7 +60,7 @@ class ExpoLaunchArgumentsModule : Module() {
     }
 
     private fun getCurrentActivity (): Activity {
-        return appContext.activityProvider?.currentActivity ?: throw CurrentActivityNotFoundException()
+      return appContext.activityProvider?.currentActivity
     }
 
     private fun parseDetoxExtras(map: HashMap<String, Any>, intent: Intent) {

--- a/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
+++ b/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
@@ -2,21 +2,99 @@ package expo.modules.launcharguments
 
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.core.interfaces.ActivityProvider
+
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.exception.CodedException
+
+import android.content.Intent
+import android.app.Activity
+import expo.modules.core.errors.CurrentActivityNotFoundException
+import java.util.HashMap
+
+const val MODULE_NAME = "ExpoLaunchArguments"
 
 class ExpoLaunchArgumentsModule : Module() {
-  // Each module class must implement the definition function. The definition consists of components
-  // that describes the module's functionality and behavior.
-  // See https://docs.expo.dev/modules/module-api for more details about available components.
-  override fun definition() = ModuleDefinition {
-    // Sets the name of the module that JavaScript code will use to refer to the module. Takes a string as an argument.
-    // Can be inferred from module's class name, but it's recommended to set it explicitly for clarity.
-    // The module will be accessible from `requireNativeModule('ExpoLaunchArguments')` in JavaScript.
-    Name("ExpoLaunchArguments")
 
-    // Sets constant properties on the module. Can take a dictionary or a closure that returns a dictionary.
-    Constants(
-      "launchArguments" to mapOf<String, String>()
-    )
+  init {
+        waitForActivity()
+    }
 
-  }
+    override fun definition() = ModuleDefinition {
+        Name(MODULE_NAME)
+
+        Constants {
+          return@Constants mapOf(
+            "launchArguments" to parseIntentExtras()
+          )
+        }
+    }
+
+    private val DETOX_LAUNCH_ARGS_KEY = "launchArgs"
+    private val ACTIVITY_WAIT_INTERVAL = 100L // Can be adjusted as needed
+    private val ACTIVITY_WAIT_TRIES = 200 // Can be adjusted as needed
+
+
+    private fun waitForActivity() {
+        var tries = 0
+        while (tries < ACTIVITY_WAIT_TRIES && getCurrentActivity() == null) {
+            sleep(ACTIVITY_WAIT_INTERVAL)
+            tries++
+        }
+    }
+
+    private fun parseIntentExtras(): HashMap<String, Any> {
+        val map = HashMap<String, Any>()
+
+        var activity = getCurrentActivity()
+        if(activity == null) {
+          return map
+        }
+
+        val intent = activity.intent
+        if (intent == null) {
+          return map
+        }
+
+        parseDetoxExtras(map, intent)
+        parseADBArgsExtras(map, intent)
+        return map
+    }
+
+    private fun getCurrentActivity (): Activity {
+        return appContext.activityProvider?.currentActivity ?: throw CurrentActivityNotFoundException()
+    }
+
+    private fun parseDetoxExtras(map: HashMap<String, Any>, intent: Intent) {
+        val bundle = intent.getBundleExtra(DETOX_LAUNCH_ARGS_KEY)
+        if (bundle != null) {
+            for (key in bundle.keySet()) {
+                map[key] = bundle.getString(key) ?: ""
+            }
+        }
+    }
+
+    private fun parseADBArgsExtras(map: HashMap<String, Any>, intent: Intent) {
+        val bundleExtras = intent.extras
+        if (bundleExtras != null) {
+            for (key in bundleExtras.keySet()) {
+                if (key != DETOX_LAUNCH_ARGS_KEY && key != "android.nfc.extra.NDEF_MESSAGES") {
+                    val value = bundleExtras.get(key)
+                    if (value is Int || value is Double || value is Boolean || value is String) {
+                        map[key] = value
+                    } else if (value != null) {
+                        map[key] = value.toString()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun sleep(ms: Long) {
+        try {
+            Thread.sleep(ms)
+        } catch (e: InterruptedException) {
+            e.printStackTrace()
+        }
+    }
 }

--- a/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
+++ b/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
@@ -2,97 +2,116 @@ package expo.modules.launcharguments
 
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.core.interfaces.Package
+import expo.modules.core.interfaces.ReactActivityLifecycleListener
 import expo.modules.core.interfaces.ActivityProvider
-
-import expo.modules.kotlin.Promise
-import expo.modules.kotlin.exception.CodedException
-
-import android.content.Intent
+import expo.modules.core.Promise
+import expo.modules.core.ExportedModule
+import android.os.Bundle
 import android.app.Activity
-import expo.modules.core.errors.CurrentActivityNotFoundException
+import android.content.Context
+import android.content.Intent
 import java.util.HashMap
 
 const val MODULE_NAME = "ExpoLaunchArguments"
 
+class ExpoLaunchArgumentsPackage : Package {
+    override fun createReactActivityLifecycleListeners(activityContext: Context): List<ReactActivityLifecycleListener> {
+        return listOf(ExpoLaunchArgumentsActivityLifecycleListener())
+    }
+}
+
+class ExpoLaunchArgumentsActivityLifecycleListener : ReactActivityLifecycleListener {
+    override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
+        val module = ExpoLaunchArgumentsModule.getModule()
+        module.setParsedIntentExtrasFromIntent(activity.intent)
+    }
+}
+
 class ExpoLaunchArgumentsModule : Module() {
-
-    override fun definition() = ModuleDefinition {
-        Name(MODULE_NAME)
-
-        Constants {
-          return@Constants mapOf(
-            "launchArguments" to parseIntentExtras()
-          )
-        }
-    }
-
     private val DETOX_LAUNCH_ARGS_KEY = "launchArgs"
-    private val ACTIVITY_WAIT_INTERVAL = 100L // Can be adjusted as needed
-    private val ACTIVITY_WAIT_TRIES = 200 // Can be adjusted as needed
+    private val ACTIVITY_WAIT_INTERVAL = 100L
+    private val ACTIVITY_WAIT_TRIES = 200
+    private var parsedIntentExtras: HashMap<String, Any>? = null
 
+     override fun definition() = ModuleDefinition {
+      Name(MODULE_NAME)
+      Constants {
+          waitForActivity()
+          val arguments: HashMap<String, Any>
+          arguments = HashMap(parsedIntentExtras ?: HashMap())
+          return@Constants mapOf(
+              "launchArguments" to arguments
+          )
+      }
+    }
 
-    private fun waitForActivity() {
-        var tries = 0
-        while (tries < ACTIVITY_WAIT_TRIES && getCurrentActivity() == null) {
-            sleep(ACTIVITY_WAIT_INTERVAL)
-            tries++
+    companion object {
+        private lateinit var instance: ExpoLaunchArgumentsModule
+
+        fun getModule(): ExpoLaunchArgumentsModule {
+            return instance
         }
     }
 
-    private fun parseIntentExtras(): HashMap<String, Any> {
-        val map = HashMap<String, Any>()
 
-        waitForActivity()
-
-        var activity = getCurrentActivity()
-        if(activity == null) {
-          return map
-        }
-
-        val intent = activity.intent
-        if (intent == null) {
-          return map
-        }
-
-        parseDetoxExtras(map, intent)
-        parseADBArgsExtras(map, intent)
-        return map
+    fun setParsedIntentExtrasFromIntent(intent: Intent) {
+      parsedIntentExtras = parseIntentExtrasFromIntent(intent)
     }
 
-    private fun getCurrentActivity (): Activity? {
-      return appContext.activityProvider?.currentActivity
+    private fun parseIntentExtrasFromIntent(intent: Intent): HashMap<String, Any> {
+      val map = HashMap<String, Any>()
+
+      if (intent == null) {
+          return map
+      }
+      map.put("intent", intent.toString())
+      parseDetoxExtras(map, intent)
+      parseADBArgsExtras(map, intent)
+      return map
     }
 
     private fun parseDetoxExtras(map: HashMap<String, Any>, intent: Intent) {
-        val bundle = intent.getBundleExtra(DETOX_LAUNCH_ARGS_KEY)
-        if (bundle != null) {
-            for (key in bundle.keySet()) {
-                map[key] = bundle.getString(key) ?: ""
-            }
-        }
+      val extrasBundle = intent.getBundleExtra(DETOX_LAUNCH_ARGS_KEY)
+      if (extrasBundle != null) {
+          map.put("extrasBundle", extrasBundle.toString())
+          for (key in extrasBundle.keySet()) {
+              map[key] = extrasBundle.getString(key) ?: ""
+          }
+      }
     }
 
     private fun parseADBArgsExtras(map: HashMap<String, Any>, intent: Intent) {
-        val bundleExtras = intent.extras
-        if (bundleExtras != null) {
-            for (key in bundleExtras.keySet()) {
-                if (key != DETOX_LAUNCH_ARGS_KEY && key != "android.nfc.extra.NDEF_MESSAGES") {
-                    val value = bundleExtras.get(key)
-                    if (value is Int || value is Double || value is Boolean || value is String) {
-                        map[key] = value
-                    } else if (value != null) {
-                        map[key] = value.toString()
-                    }
-                }
-            }
-        }
+      val bundleExtras = intent.extras
+      if (bundleExtras != null) {
+          map.put("bundleExtras", bundleExtras.toString())
+          for (key in bundleExtras.keySet()) {
+              if (key != DETOX_LAUNCH_ARGS_KEY && key != "android.nfc.extra.NDEF_MESSAGES") {
+                  val value = bundleExtras.get(key)
+                  if (value is Int || value is Double || value is Boolean || value is String) {
+                      map[key] = value
+                  } else if (value != null) {
+                      map[key] = value.toString()
+                  }
+              }
+          }
+      }
+    }
+
+
+    private fun waitForActivity() {
+      var tries = 0
+      while (tries < ACTIVITY_WAIT_TRIES && parsedIntentExtras === null) {
+          sleep(ACTIVITY_WAIT_INTERVAL)
+          tries++
+      }
     }
 
     private fun sleep(ms: Long) {
-        try {
-            Thread.sleep(ms)
-        } catch (e: InterruptedException) {
-            e.printStackTrace()
-        }
-    }
+      try {
+          Thread.sleep(ms)
+      } catch (e: InterruptedException) {
+          e.printStackTrace()
+      }
+  }
 }

--- a/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
+++ b/android/src/main/java/expo/modules/launcharguments/ExpoLaunchArgumentsModule.kt
@@ -59,7 +59,7 @@ class ExpoLaunchArgumentsModule : Module() {
         return map
     }
 
-    private fun getCurrentActivity (): Activity {
+    private fun getCurrentActivity (): Activity? {
       return appContext.activityProvider?.currentActivity
     }
 


### PR DESCRIPTION
Updated `ExpoLaunchArgumentsModule.kt` to retrieve `launchArguments` following what is done in [here](https://github.com/iamolegga/react-native-launch-arguments/blob/master/android/src/main/java/com/reactnativelauncharguments/LaunchArgumentsModule.java).
